### PR TITLE
Split docker build and publish stages for staging and production work…

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -171,42 +171,126 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push Docker image
+    - name: Build Docker image (no push)
       uses: docker/build-push-action@v5
       with:
         context: .
         file: ./Dockerfile
-        push: true
+        push: false
         tags: |
           ghcr.io/${{ github.repository }}:latest
           ghcr.io/${{ github.repository }}:prod-${{ github.sha }}
           ghcr.io/${{ github.repository }}:v${{ github.run_number }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        outputs: type=docker,dest=/tmp/image.tar
         labels: |
           org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           org.opencontainers.image.description=MyFinance Client - Production Build
           org.opencontainers.image.licenses=MIT
 
+    - name: Upload Docker image artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-image-production
+        path: /tmp/image.tar
+        retention-days: 90
+
+  docker-publish:
+    runs-on: ubuntu-latest
+    needs: [docker-build]
+    # Only run when docker-build runs (i.e., on merged PRs)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/production'
+    
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Download Docker image artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: docker-image-production
+        path: /tmp
+
+    - name: Load Docker image
+      run: |
+        docker load --input /tmp/image.tar
+        docker image ls -a
+
+    - name: Push Docker image to registry
+      run: |
+        docker push ghcr.io/${{ github.repository }}:latest
+        docker push ghcr.io/${{ github.repository }}:prod-${{ github.sha }}
+        docker push ghcr.io/${{ github.repository }}:v${{ github.run_number }}
+
     - name: Make package public
       run: |
-        # Make the package public automatically
-        curl -X PATCH \
+        echo "Attempting to make package public..."
+        
+        # Wait a moment for package to be fully created
+        sleep 10
+        
+        # Try organization endpoint first, then user endpoint
+        if curl -s -X PATCH \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/client \
-          -d '{"visibility":"public"}' || \
-        curl -X PATCH \
+          -d '{"visibility":"public"}'; then
+          echo "✅ Package made public via organization endpoint"
+        elif curl -s -X PATCH \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/user/packages/container/client \
-          -d '{"visibility":"public"}' || echo "Package might already be public or this is the first push"
+          -d '{"visibility":"public"}'; then
+          echo "✅ Package made public via user endpoint"
+        else
+          echo "⚠️ Could not set package visibility - this is normal for new packages"
+          echo "Package will be public by default or you can set it manually in GitHub"
+        fi
+
+    - name: Verify image publication
+      run: |
+        echo "Verifying image was published successfully..."
+        
+        # Check if we can pull the image we just pushed
+        if docker pull ghcr.io/${{ github.repository }}:latest; then
+          echo "✅ Image successfully published and accessible"
+          docker image ls ghcr.io/${{ github.repository }}:latest
+        else
+          echo "❌ Failed to pull published image"
+          exit 1
+        fi
+
+    - name: Image publication summary
+      run: |
+        echo "## 🚀 Docker Image Published Successfully" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Registry:** GitHub Container Registry" >> $GITHUB_STEP_SUMMARY
+        echo "**Image:** \`ghcr.io/${{ github.repository }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+        echo "- \`latest\`" >> $GITHUB_STEP_SUMMARY
+        echo "- \`prod-${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- \`v${{ github.run_number }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Pull Command:**" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "docker pull ghcr.io/${{ github.repository }}:latest" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Package URL:** [View in GitHub](https://github.com/${{ github.repository }}/pkgs/container/client)" >> $GITHUB_STEP_SUMMARY
 
   deploy-production:
     runs-on: ubuntu-latest
-    needs: docker-build
+    needs: docker-publish
     environment: production
-    # Only run when docker-build runs (i.e., on merged PRs)
+    # Only run when docker-publish runs (i.e., on merged PRs)
     if: github.event_name == 'push' && github.ref == 'refs/heads/production'
     
     steps:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -169,41 +169,123 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push Docker image
+    - name: Build Docker image (no push)
       uses: docker/build-push-action@v5
       with:
         context: .
         file: ./Dockerfile
-        push: true
+        push: false
         tags: |
           ghcr.io/${{ github.repository }}:staging-latest
           ghcr.io/${{ github.repository }}:staging-${{ github.sha }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        outputs: type=docker,dest=/tmp/image.tar
         labels: |
           org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           org.opencontainers.image.description=MyFinance Client - Staging Build
           org.opencontainers.image.licenses=MIT
 
+    - name: Upload Docker image artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-image-staging
+        path: /tmp/image.tar
+        retention-days: 30
+
+  docker-publish:
+    runs-on: ubuntu-latest
+    needs: [docker-build]
+    # Only run when docker-build runs (i.e., on merged PRs)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
+    
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Download Docker image artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: docker-image-staging
+        path: /tmp
+
+    - name: Load Docker image
+      run: |
+        docker load --input /tmp/image.tar
+        docker image ls -a
+
+    - name: Push Docker image to registry
+      run: |
+        docker push ghcr.io/${{ github.repository }}:staging-latest
+        docker push ghcr.io/${{ github.repository }}:staging-${{ github.sha }}
+
     - name: Make package public
       run: |
-        # Make the package public automatically
-        curl -X PATCH \
+        echo "Attempting to make package public..."
+        
+        # Wait a moment for package to be fully created
+        sleep 10
+        
+        # Try organization endpoint first, then user endpoint
+        if curl -s -X PATCH \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/client \
-          -d '{"visibility":"public"}' || \
-        curl -X PATCH \
+          -d '{"visibility":"public"}'; then
+          echo "✅ Package made public via organization endpoint"
+        elif curl -s -X PATCH \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/user/packages/container/client \
-          -d '{"visibility":"public"}' || echo "Package might already be public or this is the first push"
+          -d '{"visibility":"public"}'; then
+          echo "✅ Package made public via user endpoint"
+        else
+          echo "⚠️ Could not set package visibility - this is normal for new packages"
+          echo "Package will be public by default or you can set it manually in GitHub"
+        fi
+
+    - name: Verify image publication
+      run: |
+        echo "Verifying image was published successfully..."
+        
+        # Check if we can pull the image we just pushed
+        if docker pull ghcr.io/${{ github.repository }}:staging-latest; then
+          echo "✅ Image successfully published and accessible"
+          docker image ls ghcr.io/${{ github.repository }}:staging-latest
+        else
+          echo "❌ Failed to pull published image"
+          exit 1
+        fi
+
+    - name: Image publication summary
+      run: |
+        echo "## 🚀 Docker Image Published Successfully" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Registry:** GitHub Container Registry" >> $GITHUB_STEP_SUMMARY
+        echo "**Image:** \`ghcr.io/${{ github.repository }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+        echo "- \`staging-latest\`" >> $GITHUB_STEP_SUMMARY
+        echo "- \`staging-${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Pull Command:**" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+        echo "docker pull ghcr.io/${{ github.repository }}:staging-latest" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "**Package URL:** [View in GitHub](https://github.com/${{ github.repository }}/pkgs/container/client)" >> $GITHUB_STEP_SUMMARY
 
   deploy-staging:
     runs-on: ubuntu-latest
-    needs: [docker-build]
+    needs: [docker-publish]
     environment: staging
-    # Only run when docker-build runs (i.e., on merged PRs)
+    # Only run when docker-publish runs (i.e., on merged PRs)
     if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
     
     steps:


### PR DESCRIPTION
…flows

- Separated combined docker build/push into discrete build and publish stages
- docker-build: Creates Docker image and saves as artifact
- docker-publish: Loads artifact and pushes to registry
- Updated job dependencies: deploy jobs now depend on docker-publish
- Matches development workflow pattern for consistency
- Improves pipeline visibility and debugging capabilities